### PR TITLE
Editor: Use a non-persistent object cache instead of transient in `wp…

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -753,7 +753,7 @@ function wp_start_object_cache() {
 			)
 		);
 
-		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
+		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
 	}
 
 	$first_init = false;

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -575,7 +575,7 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
 				);
 			}
 
-			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
+			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
 		}
 	}
 
@@ -666,7 +666,7 @@ function restore_current_blog() {
 				);
 			}
 
-			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
+			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
 		}
 	}
 

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -401,7 +401,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 			)
 		);
 
-		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
+		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -270,4 +270,18 @@ class Tests_Theme_wpGetGlobalStylesheet extends WP_UnitTestCase {
 			'Registered styles with handle of "wp-style-engine-my-styles" do not match expected value from the Style Engine store.'
 		);
 	}
+	/**
+	 * Tests that switching themes recalculates the stylesheet.
+	 *
+	 * @ticket 56970
+	 */
+	public function test_switching_themes_should_recalculate_stylesheet() {
+		$stylesheet_for_default_theme = wp_get_global_stylesheet();
+		switch_theme( 'block-theme' );
+		$stylesheet_for_block_theme = wp_get_global_stylesheet();
+		switch_theme( WP_DEFAULT_THEME );
+
+		$this->assertStringNotContainsString( '--wp--preset--font-size--custom: 100px;', $stylesheet_for_default_theme, 'custom font size (100px) not present for default theme' );
+		$this->assertStringContainsString( '--wp--preset--font-size--custom: 100px;', $stylesheet_for_block_theme, 'custom font size (100px) is present for block theme' );
+	}
 }


### PR DESCRIPTION
…_get_global_stylesheet()`.

This changeset is part of a greater effort to enhance the caching strategy for `theme.json` based data. Similar to [55138], the cache is currently ignored when `WP_DEBUG` is on to avoid interrupting the theme developer's workflow.

Props oandregal, spacedmonkey, hellofromtonya, flixos90, ironprogrammer, azaozz, aristath, costdev, mcsf. Fixes #56910.


git-svn-id: https://develop.svn.wordpress.org/trunk@55148 602fd350-edb4-49c9-b593-d223f7449a82

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
